### PR TITLE
Use edgerc

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,3 +11,6 @@ Revision history for edgegrid-perl
 
 1.0.4 2014-10-16
  - Fix broken link
+
+1.0.5 2015-09-10
+ - Add edgerc support

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,7 +22,8 @@ WriteMakefile(
     },
     PREREQ_PM => {
         'LWP' => 5.834,
-	'Data::UUID' => 0
+	'Data::UUID' => 0,
+	'Config::IniFiles' => 0
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Akamai-Edgegrid-*' },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,14 +16,14 @@ WriteMakefile(
     },
     BUILD_REQUIRES => {
         'Test::More' => 0,
-	'Test::Pod::Coverage' => 0,
-	'Test::Pod' => 1.22,
+        'Test::Pod::Coverage' => 0,
+        'Test::Pod' => 1.22,
         'JSON' => 0
     },
     PREREQ_PM => {
         'LWP' => 5.834,
-	'Data::UUID' => 0,
-	'Config::IniFiles' => 0
+        'Data::UUID' => 0,
+        'Config::IniFiles' => 0
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Akamai-Edgegrid-*' },

--- a/lib/Akamai/Edgegrid.pm
+++ b/lib/Akamai/Edgegrid.pm
@@ -28,8 +28,8 @@ our $VERSION = '1.0.4';
     use Akamai::Edgegrid;
 
     my $agent = new Akamai::Edgegrid(
-                        config_file => "$ENV{HOME}/.edgerc",
-                        section   => "default" );
+                    config_file => "$ENV{HOME}/.edgerc",
+                    section   => "default");
     my $baseurl = "https://" . $agent->{host};
 
     my $resp = $agent->get("$baseurl/diagnostic-tools/v1/locations");
@@ -215,36 +215,35 @@ sub new {
     for my $arg (@local_args) {
         $local{$arg} = delete $args{$arg};
     }
-    
+
     my $self = LWP::UserAgent::new($class, %args);
 
     for my $arg (@local_args) {
         $self->{$arg} = $local{$arg};
     }
-    
+
     # defaults
     unless ($self->{config_file}) {
-	$self->{config_file} = "$ENV{HOME}/.edgerc";
+        $self->{config_file} = "$ENV{HOME}/.edgerc";
     }
     if (-f $self->{config_file} and $self->{section} ) {
-	my $cfg = Config::IniFiles->new( -file => $self->{config_file} );
-    	for my $variable (@cred_args) {
-		if ($cfg->val($self->{section}, $variable)) {
-       			$self->{$variable} = $cfg->val($self->{section}, $variable);
-		} else {
-			die ("Config file " .
-				$self->{config_file} .
-				" is missing required argument " . $variable .
-				" in section " . $self->{section} );
-		}
-	}
-    	if ( $cfg->val($self->{section}, "max_body") ) {
-		$self->{max_body} = $cfg->val($self->{section}, "max_body");
-    	}
+        my $cfg = Config::IniFiles->new( -file => $self->{config_file} );
+        for my $variable (@cred_args) {
+            if ($cfg->val($self->{section}, $variable)) {
+                $self->{$variable} = $cfg->val($self->{section}, $variable);
+            } else {
+                die ("Config file " .  $self->{config_file} .
+                    " is missing required argument " . $variable .
+                    " in section " . $self->{section} );
+            }
+        }
+        if ( $cfg->val($self->{section}, "max_body") ) {
+            $self->{max_body} = $cfg->val($self->{section}, "max_body");
+        }
     }
 
     for my $arg (@required_args) {
-	unless ($self->{$arg}) {
+    unless ($self->{$arg}) {
             die "missing required argument $arg";
         }
     }
@@ -256,7 +255,6 @@ sub new {
         $self->{max_body} = 131072;
     }
 
-    
     $self->add_handler('request_prepare' => sub {
         my ($r, $ua, $h) = @_;
 

--- a/lib/Akamai/Edgegrid.pm
+++ b/lib/Akamai/Edgegrid.pm
@@ -21,7 +21,7 @@ Version 1.0
 
 =cut
 
-our $VERSION = '1.0.4';
+our $VERSION = '1.0.5';
 
 =head1 SYNOPSIS
 

--- a/lib/Akamai/Edgegrid.pm
+++ b/lib/Akamai/Edgegrid.pm
@@ -9,6 +9,7 @@ use Data::Dumper;
 use Digest::SHA qw(hmac_sha256_base64 sha256_base64);
 use POSIX qw(strftime);
 use Data::UUID;
+use Config::IniFiles;
 
 =head1 NAME
 
@@ -26,12 +27,10 @@ our $VERSION = '1.0.4';
 
     use Akamai::Edgegrid;
 
-    my $baseurl = 'https://akaa-bbbbbbbbbbbbb.luna.akamaiapis.net';
     my $agent = new Akamai::Edgegrid(
-        client_token => 'cccccccccccccccc',
-        client_secret => 'sssssssssssssssss',
-        access_token => 'aaaaaaaaaaaaaaaaaaaa'
-    );
+                        config_file => "$ENV{HOME}/.edgerc",
+                        section   => "default" );
+    my $baseurl = "https://" . $agent->{host};
 
     my $resp = $agent->get("$baseurl/diagnostic-tools/v1/locations");
     print $resp->content;
@@ -208,8 +207,9 @@ sub new {
     my $class = shift @_;
     my %args = @_;
 
-    my @local_args = qw(client_token client_secret access_token headers_to_sign max_body debug);
-    my @required_args = qw(client_token client_secret access_token);
+    my @local_args = qw(config_file section headers_to_sign max_body debug);
+    my @required_args = qw(config_file section);
+    my @cred_args = qw(client_token access_token host client_secret);
     my %local = ();
 
     for my $arg (@local_args) {
@@ -221,21 +221,34 @@ sub new {
     for my $arg (@local_args) {
         $self->{$arg} = $local{$arg};
     }
-
-    for my $arg (@required_args) {
-        unless ($self->{$arg}) {
-            die "missing required argument $arg";
-        }
-    }
-
+    
     # defaults
+    unless ($self->{config_file}) {
+	$self->{config_file} = "$ENV{HOME}/.edgerc";
+    }
     unless ($self->{headers_to_sign}) {
         $self->{headers_to_sign} = [];
     }
     unless ($self->{max_body}) {
-        $self->{max_body} = 2048;
+        $self->{max_body} = 131072;
     }
 
+    print $self->{config_file};
+    print $self->{section};
+    my $cfg = Config::IniFiles->new( -file => $self->{config_file} );
+    for my $variable (@cred_args) {
+	print $self->{section};
+	print $variable;
+	print $variable;
+	$self->{$variable} = $cfg->val($self->{section}, $variable);
+	print $variable;
+	print $self->{$variable}
+    }
+
+    if ( $cfg->val($self->{section}, "max_body") ) {
+	$self->{max_body} = $cfg->val($self->{section}, "max_body");
+    }
+    
     $self->add_handler('request_prepare' => sub {
         my ($r, $ua, $h) = @_;
 

--- a/t/04-defaultargs.t
+++ b/t/04-defaultargs.t
@@ -18,7 +18,7 @@ plan tests=>2;
 my $ua = new Akamai::Edgegrid(client_token=>'xxx', client_secret=>'xxx',
     access_token=>'xxx');
 
-is($ua->{max_body}, 2048, 'default max_body=2048');
+is($ua->{max_body},131072 , 'default max_body=131072');
 is_deeply($ua->{headers_to_sign}, [], 'default headers_to_sign=[]');
 
 =head1 LICENSE AND COPYRIGHT


### PR DESCRIPTION
This change uses Config::IniFiles to read the credential information (and host information) from the ~/.edgerc file.  Doc info has been updated to the new format.

I'll add the examples in examples/perl in the api-kickstart repo once this is pulled.

